### PR TITLE
fix(isSpot): use spot cache for EKS only

### DIFF
--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -94,7 +94,9 @@ func TestController_HappyPath(t *testing.T) {
 		Do(func(ctx context.Context, clusterID string, req *castai.AgentTelemetryRequest) {
 			require.Equalf(t, "1.2.3", req.AgentVersion, "got request: %+v", req)
 		})
-	provider.EXPECT().IsSpot(gomock.Any(), node).Return(true, nil)
+
+	provider.EXPECT().IsSpot(gomock.Any(), node).Return(true, nil).Times(1)
+	provider.EXPECT().IsSpot(gomock.Any(), expectedNode).Return(true, nil).Times(1)
 
 	f := informers.NewSharedInformerFactory(clientset, 0)
 	log := logrus.New()

--- a/internal/services/providers/eks/eks_test.go
+++ b/internal/services/providers/eks/eks_test.go
@@ -67,6 +67,7 @@ func TestProvider_IsSpot(t *testing.T) {
 		p := &Provider{
 			log:       logrus.New(),
 			awsClient: awsClient,
+			spotCache: map[string]bool{},
 		}
 
 		got, err := p.IsSpot(context.Background(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
@@ -83,6 +84,7 @@ func TestProvider_IsSpot(t *testing.T) {
 		p := &Provider{
 			log:       logrus.New(),
 			awsClient: awsClient,
+			spotCache: map[string]bool{},
 		}
 
 		got, err := p.IsSpot(context.Background(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
@@ -99,6 +101,7 @@ func TestProvider_IsSpot(t *testing.T) {
 		p := &Provider{
 			log:       logrus.New(),
 			awsClient: awsClient,
+			spotCache: map[string]bool{},
 		}
 
 		awsClient.EXPECT().GetInstancesByPrivateDNS(gomock.Any(), []string{"hostname"}).Return([]*ec2.Instance{
@@ -121,6 +124,7 @@ func TestProvider_IsSpot(t *testing.T) {
 		p := &Provider{
 			log:       logrus.New(),
 			awsClient: awsClient,
+			spotCache: map[string]bool{},
 		}
 
 		awsClient.EXPECT().GetInstancesByPrivateDNS(gomock.Any(), []string{"hostname"}).Return([]*ec2.Instance{


### PR DESCRIPTION
- GKE adds labels to the nodes after creation
- This means we should not be using spot cache for GKE, there is no need for that
- The cache was used as a historical reason because on the EKS side, we actually need to execute API call to identify whether some of the nodes are Spot