### PR TITLE
chore: optimize spot node discovery

### DIFF
--- a/internal/castai/castai.go
+++ b/internal/castai/castai.go
@@ -8,11 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"

--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -2,7 +2,6 @@
 package controller
 
 import (
-	"castai-agent/pkg/labels"
 	"context"
 	"fmt"
 	"reflect"
@@ -25,6 +24,7 @@ import (
 	"castai-agent/internal/config"
 	"castai-agent/internal/services/providers/types"
 	"castai-agent/internal/services/version"
+	"castai-agent/pkg/labels"
 )
 
 var (

--- a/internal/services/controller/controller_exclude_race_test.go
+++ b/internal/services/controller/controller_exclude_race_test.go
@@ -10,11 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"castai-agent/internal/castai"
-	mock_castai "castai-agent/internal/castai/mock"
-	"castai-agent/internal/config"
-	mock_types "castai-agent/internal/services/providers/types/mock"
-	mock_version "castai-agent/internal/services/version/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -24,6 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"castai-agent/internal/castai"
+	mock_castai "castai-agent/internal/castai/mock"
+	"castai-agent/internal/config"
+	mock_types "castai-agent/internal/services/providers/types/mock"
+	mock_version "castai-agent/internal/services/version/mock"
 )
 
 func TestController_ShouldKeepDeltaAfterDelete(t *testing.T) {

--- a/internal/services/controller/controller_exclude_race_test.go
+++ b/internal/services/controller/controller_exclude_race_test.go
@@ -25,12 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-
-	"castai-agent/internal/castai"
-	mock_castai "castai-agent/internal/castai/mock"
-	"castai-agent/internal/config"
-	mock_types "castai-agent/internal/services/providers/types/mock"
-	mock_version "castai-agent/internal/services/version/mock"
 )
 
 func TestController_ShouldKeepDeltaAfterDelete(t *testing.T) {

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -95,8 +95,7 @@ func TestController_HappyPath(t *testing.T) {
 			require.Equalf(t, "1.2.3", req.AgentVersion, "got request: %+v", req)
 		})
 
-	provider.EXPECT().IsSpot(gomock.Any(), node).Return(true, nil).Times(1)
-	provider.EXPECT().IsSpot(gomock.Any(), expectedNode).Return(true, nil).Times(1)
+	provider.EXPECT().FilterSpot(gomock.Any(), []*v1.Node{node}).Return([]*v1.Node{node}, nil)
 
 	f := informers.NewSharedInformerFactory(clientset, 0)
 	log := logrus.New()

--- a/internal/services/providers/aks/aks.go
+++ b/internal/services/providers/aks/aks.go
@@ -89,11 +89,18 @@ func failedAutodiscovery(err error, envVar string) error {
 	return fmt.Errorf("autodiscovering cluster metadata: %w: provide required %s environment variable", err, envVar)
 }
 
-func (p *Provider) IsSpot(_ context.Context, node *corev1.Node) (bool, error) {
-	if val, ok := node.ObjectMeta.Labels["kubernetes.azure.com/scalesetpriority"]; ok {
-		return val == "spot", nil
+func (p *Provider) FilterSpot(_ context.Context, nodes []*corev1.Node) ([]*corev1.Node, error) {
+	var ret []*corev1.Node
+
+	for _, node := range nodes {
+		if val, ok := node.ObjectMeta.Labels["kubernetes.azure.com/scalesetpriority"]; !ok || val != "spot" {
+			continue
+		}
+
+		ret = append(ret, node)
 	}
-	return false, nil
+
+	return ret, nil
 }
 
 func (p *Provider) Name() string {

--- a/internal/services/providers/aks/aks_test.go
+++ b/internal/services/providers/aks/aks_test.go
@@ -60,11 +60,13 @@ func TestProvider_IsSpot(t *testing.T) {
 			log: logrus.New(),
 		}
 
-		got, err := p.IsSpot(context.Background(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			SpotLabelKey: SpotLabelVal,
-		}}})
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{SpotLabelKey: SpotLabelVal}},
+		}
+
+		got, err := p.FilterSpot(context.Background(), []*v1.Node{node})
 
 		require.NoError(t, err)
-		require.True(t, got)
+		require.Equal(t, []*v1.Node{node}, got)
 	})
 }

--- a/internal/services/providers/castai/castai.go
+++ b/internal/services/providers/castai/castai.go
@@ -2,7 +2,6 @@ package castai
 
 import (
 	"context"
-
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 
@@ -24,11 +23,16 @@ type Provider struct {
 	log logrus.FieldLogger
 }
 
-func (p *Provider) IsSpot(_ context.Context, node *v1.Node) (bool, error) {
-	if val, ok := node.Labels[labels.CastaiSpot]; ok && val == "true" {
-		return true, nil
+func (p *Provider) FilterSpot(_ context.Context, nodes []*v1.Node) ([]*v1.Node, error) {
+	var ret []*v1.Node
+
+	for _, node := range nodes {
+		if val, ok := node.Labels[labels.CastaiSpot]; ok && val == "true" {
+			ret = append(ret, node)
+		}
 	}
-	return false, nil
+
+	return ret, nil
 }
 
 func (p *Provider) RegisterCluster(_ context.Context, _ castai.Client) (*types.ClusterRegistration, error) {

--- a/internal/services/providers/castai/castai.go
+++ b/internal/services/providers/castai/castai.go
@@ -2,6 +2,7 @@ package castai
 
 import (
 	"context"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 

--- a/internal/services/providers/eks/eks.go
+++ b/internal/services/providers/eks/eks.go
@@ -3,6 +3,7 @@ package eks
 import (
 	"context"
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 

--- a/internal/services/providers/gke/gke.go
+++ b/internal/services/providers/gke/gke.go
@@ -3,6 +3,7 @@ package gke
 import (
 	"context"
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 

--- a/internal/services/providers/gke/gke.go
+++ b/internal/services/providers/gke/gke.go
@@ -3,7 +3,6 @@ package gke
 import (
 	"context"
 	"fmt"
-
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 
@@ -99,20 +98,32 @@ func failedAutodiscovery(err error, envVar string) error {
 	return fmt.Errorf("autodiscovering cluster metadata: %w\nProvide required %s environment variable", err, envVar)
 }
 
-func (p *Provider) IsSpot(_ context.Context, node *corev1.Node) (bool, error) {
+func isSpot(node *corev1.Node) bool {
 	if val, ok := node.Labels[labels.CastaiSpot]; ok && val == "true" {
-		return true, nil
+		return true
 	}
 
 	if val, ok := node.Labels[LabelPreemptible]; ok && val == "true" {
-		return true, nil
+		return true
 	}
 
 	if val, ok := node.Labels[LabelSpot]; ok && val == "true" {
-		return true, nil
+		return true
 	}
 
-	return false, nil
+	return false
+}
+
+func (p *Provider) FilterSpot(_ context.Context, nodes []*corev1.Node) ([]*corev1.Node, error) {
+	var ret []*corev1.Node
+
+	for _, node := range nodes {
+		if isSpot(node) {
+			ret = append(ret, node)
+		}
+	}
+
+	return ret, nil
 }
 
 func (p *Provider) Name() string {

--- a/internal/services/providers/gke/gke_test.go
+++ b/internal/services/providers/gke/gke_test.go
@@ -109,9 +109,14 @@ func TestProvider_IsSpot(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			got, err := p.IsSpot(context.Background(), test.node)
+			got, err := p.FilterSpot(context.Background(), []*v1.Node{test.node})
 			require.NoError(t, err)
-			require.Equal(t, test.expected, got)
+
+			if test.expected {
+				require.Equal(t, []*v1.Node{test.node}, got)
+			} else {
+				require.Empty(t, got)
+			}
 		})
 	}
 }

--- a/internal/services/providers/kops/kops.go
+++ b/internal/services/providers/kops/kops.go
@@ -114,7 +114,24 @@ func (p *Provider) RegisterCluster(ctx context.Context, client castai.Client) (*
 	}, nil
 }
 
-func (p *Provider) IsSpot(ctx context.Context, node *v1.Node) (bool, error) {
+func (p *Provider) FilterSpot(ctx context.Context, nodes []*v1.Node) ([]*v1.Node, error) {
+	var ret []*v1.Node
+
+	for _, node := range nodes {
+		spot, err := p.isSpot(ctx, node)
+		if err != nil {
+			return nil, fmt.Errorf("determining whether node %s is spot: %w", node.Name, err)
+		}
+
+		if spot {
+			ret = append(ret, node)
+		}
+	}
+
+	return ret, nil
+}
+
+func (p *Provider) isSpot(ctx context.Context, node *v1.Node) (bool, error) {
 	if val, ok := node.Labels[labels.CastaiSpot]; ok && val == "true" {
 		return true, nil
 	}

--- a/internal/services/providers/kops/kops_test.go
+++ b/internal/services/providers/kops/kops_test.go
@@ -177,7 +177,7 @@ func TestProvider_IsSpot(t *testing.T) {
 
 		p := &Provider{}
 
-		got, err := p.IsSpot(context.Background(), node)
+		got, err := p.isSpot(context.Background(), node)
 
 		require.NoError(t, err)
 		require.True(t, got)
@@ -194,7 +194,7 @@ func TestProvider_IsSpot(t *testing.T) {
 
 		p := &Provider{}
 
-		got, err := p.IsSpot(context.Background(), node)
+		got, err := p.isSpot(context.Background(), node)
 
 		require.NoError(t, err)
 		require.True(t, got)
@@ -222,7 +222,7 @@ func TestProvider_IsSpot(t *testing.T) {
 			},
 		}, nil)
 
-		got, err := p.IsSpot(context.Background(), node)
+		got, err := p.isSpot(context.Background(), node)
 
 		require.NoError(t, err)
 		require.True(t, got)
@@ -241,7 +241,7 @@ func TestProvider_IsSpot(t *testing.T) {
 			csp: "gcp",
 		}
 
-		got, err := p.IsSpot(context.Background(), node)
+		got, err := p.isSpot(context.Background(), node)
 
 		require.NoError(t, err)
 		require.True(t, got)
@@ -269,7 +269,7 @@ func TestProvider_IsSpot(t *testing.T) {
 			},
 		}, nil)
 
-		got, err := p.IsSpot(context.Background(), node)
+		got, err := p.isSpot(context.Background(), node)
 
 		require.NoError(t, err)
 		require.False(t, got)

--- a/internal/services/providers/providers.go
+++ b/internal/services/providers/providers.go
@@ -1,9 +1,10 @@
 package providers
 
 import (
-	"castai-agent/internal/services/providers/aks"
 	"context"
 	"fmt"
+
+	"castai-agent/internal/services/providers/aks"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"

--- a/internal/services/providers/types/mock/provider.go
+++ b/internal/services/providers/types/mock/provider.go
@@ -37,19 +37,19 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
-// IsSpot mocks base method.
-func (m *MockProvider) IsSpot(arg0 context.Context, arg1 *v1.Node) (bool, error) {
+// FilterSpot mocks base method.
+func (m *MockProvider) FilterSpot(arg0 context.Context, arg1 []*v1.Node) ([]*v1.Node, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsSpot", arg0, arg1)
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "FilterSpot", arg0, arg1)
+	ret0, _ := ret[0].([]*v1.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsSpot indicates an expected call of IsSpot.
-func (mr *MockProviderMockRecorder) IsSpot(arg0, arg1 interface{}) *gomock.Call {
+// FilterSpot indicates an expected call of FilterSpot.
+func (mr *MockProviderMockRecorder) FilterSpot(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSpot", reflect.TypeOf((*MockProvider)(nil).IsSpot), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterSpot", reflect.TypeOf((*MockProvider)(nil).FilterSpot), arg0, arg1)
 }
 
 // Name mocks base method.

--- a/internal/services/providers/types/types.go
+++ b/internal/services/providers/types/types.go
@@ -14,10 +14,10 @@ import (
 type Provider interface {
 	// RegisterCluster retrieves cluster registration data needed to correctly identify the cluster.
 	RegisterCluster(ctx context.Context, client castclient.Client) (*ClusterRegistration, error)
-	// IsSpot checks provider specific properties whether the node lifecycle is spot/preemtible.
-	IsSpot(ctx context.Context, node *v1.Node) (bool, error)
 	// Name of the provider.
 	Name() string
+	// FilterSpot checks the provider specific properties and returns only spot/preemtible nodes.
+	FilterSpot(ctx context.Context, nodes []*v1.Node) ([]*v1.Node, error)
 }
 
 // ClusterRegistration holds information needed to identify the cluster.


### PR DESCRIPTION
Agent will no longer check whether a node is spot in the informer event handler. Instead, it will do that before sending the delta request. This is needed to be able to batch the request, to avoid getting rate limit errors in cloud APIs.