### PR TITLE
CO-1540: Query AWS nodes by instanceID

### DIFF
--- a/internal/services/providers/eks/client/mock/client.go
+++ b/internal/services/providers/eks/client/mock/client.go
@@ -65,19 +65,19 @@ func (mr *MockClientMockRecorder) GetClusterName(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterName", reflect.TypeOf((*MockClient)(nil).GetClusterName), arg0)
 }
 
-// GetInstancesByPrivateDNS mocks base method.
-func (m *MockClient) GetInstancesByPrivateDNS(arg0 context.Context, arg1 []string) ([]*ec2.Instance, error) {
+// GetInstancesByInstanceIDs mocks base method.
+func (m *MockClient) GetInstancesByInstanceIDs(arg0 context.Context, arg1 []string) ([]*ec2.Instance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstancesByPrivateDNS", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetInstancesByInstanceIDs", arg0, arg1)
 	ret0, _ := ret[0].([]*ec2.Instance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetInstancesByPrivateDNS indicates an expected call of GetInstancesByPrivateDNS.
-func (mr *MockClientMockRecorder) GetInstancesByPrivateDNS(arg0, arg1 interface{}) *gomock.Call {
+// GetInstancesByInstanceIDs indicates an expected call of GetInstancesByInstanceIDs.
+func (mr *MockClientMockRecorder) GetInstancesByInstanceIDs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstancesByPrivateDNS", reflect.TypeOf((*MockClient)(nil).GetInstancesByPrivateDNS), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstancesByInstanceIDs", reflect.TypeOf((*MockClient)(nil).GetInstancesByInstanceIDs), arg0, arg1)
 }
 
 // GetRegion mocks base method.

--- a/internal/services/providers/eks/eks_test.go
+++ b/internal/services/providers/eks/eks_test.go
@@ -108,16 +108,18 @@ func TestProvider_IsSpot(t *testing.T) {
 			spotCache: map[string]bool{},
 		}
 
-		awsClient.EXPECT().GetInstancesByPrivateDNS(gomock.Any(), []string{"hostname"}).Return([]*ec2.Instance{
+		awsClient.EXPECT().GetInstancesByInstanceIDs(gomock.Any(), []string{"instanceID"}).Return([]*ec2.Instance{
 			{
-				PrivateDnsName:    pointer.StringPtr("hostname"),
+				InstanceId:        pointer.StringPtr("instanceID"),
 				InstanceLifecycle: pointer.StringPtr("spot"),
 			},
 		}, nil).Times(1)
 
-		node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			v1.LabelHostname: "hostname",
-		}}}
+		node := &v1.Node{
+			Spec: v1.NodeSpec{
+				ProviderID: "aws:///eu-west-1a/instanceID",
+			},
+		}
 
 		got, err := p.FilterSpot(context.Background(), []*v1.Node{node})
 
@@ -139,16 +141,18 @@ func TestProvider_IsSpot(t *testing.T) {
 			spotCache: map[string]bool{},
 		}
 
-		awsClient.EXPECT().GetInstancesByPrivateDNS(gomock.Any(), []string{"hostname"}).Return([]*ec2.Instance{
+		awsClient.EXPECT().GetInstancesByInstanceIDs(gomock.Any(), []string{"instanceID"}).Return([]*ec2.Instance{
 			{
-				PrivateDnsName:    pointer.StringPtr("hostname"),
+				InstanceId:        pointer.StringPtr("instanceID"),
 				InstanceLifecycle: pointer.StringPtr("on-demand"),
 			},
 		}, nil)
 
-		node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			v1.LabelHostname: "hostname",
-		}}}
+		node := &v1.Node{
+			Spec: v1.NodeSpec{
+				ProviderID: "aws:///eu-west-1a/instanceID",
+			},
+		}
 
 		got, err := p.FilterSpot(context.Background(), []*v1.Node{node})
 

--- a/internal/services/providers/kops/kops.go
+++ b/internal/services/providers/kops/kops.go
@@ -141,14 +141,12 @@ func (p *Provider) isSpot(ctx context.Context, node *v1.Node) (bool, error) {
 	}
 
 	if p.csp == "aws" && p.awsClient != nil {
-		hostname, ok := node.Labels[v1.LabelHostname]
-		if !ok {
-			return false, fmt.Errorf("label %s not found on node %s", v1.LabelHostname, node.Name)
-		}
+		splitProviderID := strings.Split(node.Spec.ProviderID, "/")
+		instanceID := splitProviderID[len(splitProviderID)-1]
 
-		instances, err := p.awsClient.GetInstancesByPrivateDNS(ctx, []string{hostname})
+		instances, err := p.awsClient.GetInstancesByInstanceIDs(ctx, []string{instanceID})
 		if err != nil {
-			return false, fmt.Errorf("getting instances by hostname: %w", err)
+			return false, fmt.Errorf("getting instances by instance IDs: %w", err)
 		}
 
 		for _, instance := range instances {

--- a/internal/services/providers/kops/kops_test.go
+++ b/internal/services/providers/kops/kops_test.go
@@ -202,10 +202,8 @@ func TestProvider_IsSpot(t *testing.T) {
 
 	t.Run("aws spot nodes", func(t *testing.T) {
 		node := &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					v1.LabelHostname: "hostname",
-				},
+			Spec: v1.NodeSpec{
+				ProviderID: "aws:///eu-west-1a/instanceID",
 			},
 		}
 
@@ -216,7 +214,7 @@ func TestProvider_IsSpot(t *testing.T) {
 			awsClient: awsclient,
 		}
 
-		awsclient.EXPECT().GetInstancesByPrivateDNS(gomock.Any(), []string{"hostname"}).Return([]*ec2.Instance{
+		awsclient.EXPECT().GetInstancesByInstanceIDs(gomock.Any(), []string{"instanceID"}).Return([]*ec2.Instance{
 			{
 				InstanceLifecycle: pointer.StringPtr("spot"),
 			},
@@ -249,10 +247,8 @@ func TestProvider_IsSpot(t *testing.T) {
 
 	t.Run("non spot node", func(t *testing.T) {
 		node := &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					v1.LabelHostname: "hostname",
-				},
+			Spec: v1.NodeSpec{
+				ProviderID: "aws:///eu-west-1a/instanceID",
 			},
 		}
 
@@ -263,7 +259,7 @@ func TestProvider_IsSpot(t *testing.T) {
 			awsClient: awsclient,
 		}
 
-		awsclient.EXPECT().GetInstancesByPrivateDNS(gomock.Any(), []string{"hostname"}).Return([]*ec2.Instance{
+		awsclient.EXPECT().GetInstancesByInstanceIDs(gomock.Any(), []string{"instanceID"}).Return([]*ec2.Instance{
 			{
 				InstanceLifecycle: pointer.StringPtr("on-demand"),
 			},


### PR DESCRIPTION
Querying nodes by `kubernetes.io/hostname` label's value is unreliable as it can be duplicated throughout the nodes. Instead, if we query the node by EC2 instance ID, we make sure we get the expected node.