### PR TITLE
feat: add healthz endpoint and graceful shutdown

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,9 +72,11 @@ type Static struct {
 }
 
 type Controller struct {
-	Interval             time.Duration `mapstructure:"interval"`
-	PrepTimeout          time.Duration `mapstructure:"prep_timeout"`
-	InitialSleepDuration time.Duration `mapstructure:"initial_sleep_duration"`
+	Interval                       time.Duration `mapstructure:"interval"`
+	PrepTimeout                    time.Duration `mapstructure:"prep_timeout"`
+	InitialSleepDuration           time.Duration `mapstructure:"initial_sleep_duration"`
+	HealthySnapshotIntervalLimit   time.Duration `mapstructure:"healthy_snapshot_interval_limit"`
+	InitializationTimeoutExtension time.Duration `mapstructure:"initialization_timeout_extension"`
 }
 
 var cfg *Config
@@ -95,6 +97,8 @@ func Get() Config {
 	viper.SetDefault("controller.interval", 15*time.Second)
 	viper.SetDefault("controller.prep_timeout", 10*time.Minute)
 	viper.SetDefault("controller.initial_sleep_duration", 30*time.Second)
+	viper.SetDefault("controller.healthy_snapshot_interval_limit", 10*time.Minute)
+	viper.SetDefault("controller.initialization_timeout_extension", 5*time.Minute)
 
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/internal/services/controller/controller_exclude_race_test.go
+++ b/internal/services/controller/controller_exclude_race_test.go
@@ -121,24 +121,17 @@ func TestController_ShouldKeepDeltaAfterDelete(t *testing.T) {
 
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
-	ctrl := New(
-		log,
-		f,
-		castaiclient,
-		provider,
-		clusterID.String(),
-		&config.Controller{
-			Interval:             2 * time.Second,
-			PrepTimeout:          2 * time.Second,
-			InitialSleepDuration: 10 * time.Millisecond,
-		},
-		version,
-		agentVersion,
-	)
+	ctrl := New(log, f, castaiclient, provider, clusterID.String(), &config.Controller{
+		Interval:             2 * time.Second,
+		PrepTimeout:          2 * time.Second,
+		InitialSleepDuration: 10 * time.Millisecond,
+	}, version, agentVersion, NewHealthzProvider(defaultHealthzCfg))
 
 	f.Start(ctx.Done())
 
-	go ctrl.Run(ctx)
+	go func() {
+		require.NoError(t, ctrl.Run(ctx))
+	}()
 
 	wait.Until(func() {
 		if atomic.LoadInt64(&invocations) >= 3 {

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -32,6 +32,14 @@ import (
 	"castai-agent/pkg/labels"
 )
 
+var defaultHealthzCfg = config.Config{Controller: &config.Controller{
+	Interval:                       15 * time.Second,
+	PrepTimeout:                    10 * time.Minute,
+	InitialSleepDuration:           30 * time.Second,
+	HealthySnapshotIntervalLimit:   10 * time.Minute,
+	InitializationTimeoutExtension: 5 * time.Minute,
+}}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(
 		m,
@@ -101,23 +109,16 @@ func TestController_HappyPath(t *testing.T) {
 	f := informers.NewSharedInformerFactory(clientset, 0)
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
-	ctrl := New(
-		log,
-		f,
-		castaiclient,
-		provider,
-		clusterID.String(),
-		&config.Controller{
-			Interval:             15 * time.Second,
-			PrepTimeout:          2 * time.Second,
-			InitialSleepDuration: 10 * time.Millisecond,
-		},
-		version,
-		agentVersion,
-	)
+	ctrl := New(log, f, castaiclient, provider, clusterID.String(), &config.Controller{
+		Interval:             15 * time.Second,
+		PrepTimeout:          2 * time.Second,
+		InitialSleepDuration: 10 * time.Millisecond,
+	}, version, agentVersion, NewHealthzProvider(defaultHealthzCfg))
 	f.Start(ctx.Done())
 
-	go ctrl.Run(ctx)
+	go func() {
+		require.NoError(t, ctrl.Run(ctx))
+	}()
 
 	wait.Until(func() {
 		if atomic.LoadInt64(&invocations) >= 1 {

--- a/internal/services/controller/healthz.go
+++ b/internal/services/controller/healthz.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"castai-agent/internal/config"
+)
+
+func NewHealthzProvider(cfg config.Config) *HealthzProvider {
+	return &HealthzProvider{
+		cfg:             cfg,
+		initHardTimeout: cfg.Controller.PrepTimeout + cfg.Controller.InitialSleepDuration + cfg.Controller.InitializationTimeoutExtension,
+	}
+}
+
+type HealthzProvider struct {
+	cfg             config.Config
+	initHardTimeout time.Duration
+
+	initializeStarted *time.Time
+	lastHealthyAction *time.Time
+}
+
+func (h *HealthzProvider) Check(_ *http.Request) error {
+	if h.lastHealthyAction != nil {
+		if time.Since(*h.lastHealthyAction) > h.cfg.Controller.HealthySnapshotIntervalLimit {
+			return fmt.Errorf("time since initialization or last snapshot sent is over the considered healthy limit of %s", h.cfg.Controller.HealthySnapshotIntervalLimit)
+		}
+		return nil
+	}
+
+	if h.initializeStarted != nil {
+		if time.Since(*h.initializeStarted) > h.initHardTimeout {
+			return fmt.Errorf("controller initialization is taking longer than the hard timeout of %s", h.initHardTimeout)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("healthz not initialized")
+}
+
+func (h *HealthzProvider) Initializing() {
+	if h.initializeStarted == nil {
+		h.initializeStarted = nowPtr()
+	}
+}
+
+func (h *HealthzProvider) Initialized() {
+	h.healthyAction()
+}
+
+func (h *HealthzProvider) SnapshotSent() {
+	h.healthyAction()
+}
+
+func (h *HealthzProvider) healthyAction() {
+	h.initializeStarted = nil
+	h.lastHealthyAction = nowPtr()
+}
+
+func nowPtr() *time.Time {
+	now := time.Now()
+	return &now
+}

--- a/internal/services/controller/healthz.go
+++ b/internal/services/controller/healthz.go
@@ -19,20 +19,20 @@ type HealthzProvider struct {
 	cfg             config.Config
 	initHardTimeout time.Duration
 
-	initializeStarted *time.Time
-	lastHealthyAction *time.Time
+	initializeStartedAt *time.Time
+	lastHealthyActionAt *time.Time
 }
 
 func (h *HealthzProvider) Check(_ *http.Request) error {
-	if h.lastHealthyAction != nil {
-		if time.Since(*h.lastHealthyAction) > h.cfg.Controller.HealthySnapshotIntervalLimit {
+	if h.lastHealthyActionAt != nil {
+		if time.Since(*h.lastHealthyActionAt) > h.cfg.Controller.HealthySnapshotIntervalLimit {
 			return fmt.Errorf("time since initialization or last snapshot sent is over the considered healthy limit of %s", h.cfg.Controller.HealthySnapshotIntervalLimit)
 		}
 		return nil
 	}
 
-	if h.initializeStarted != nil {
-		if time.Since(*h.initializeStarted) > h.initHardTimeout {
+	if h.initializeStartedAt != nil {
+		if time.Since(*h.initializeStartedAt) > h.initHardTimeout {
 			return fmt.Errorf("controller initialization is taking longer than the hard timeout of %s", h.initHardTimeout)
 		}
 		return nil
@@ -42,8 +42,9 @@ func (h *HealthzProvider) Check(_ *http.Request) error {
 }
 
 func (h *HealthzProvider) Initializing() {
-	if h.initializeStarted == nil {
-		h.initializeStarted = nowPtr()
+	if h.initializeStartedAt == nil {
+		h.initializeStartedAt = nowPtr()
+		h.lastHealthyActionAt = nil
 	}
 }
 
@@ -56,8 +57,8 @@ func (h *HealthzProvider) SnapshotSent() {
 }
 
 func (h *HealthzProvider) healthyAction() {
-	h.initializeStarted = nil
-	h.lastHealthyAction = nowPtr()
+	h.initializeStartedAt = nil
+	h.lastHealthyActionAt = nowPtr()
 }
 
 func nowPtr() *time.Time {

--- a/internal/services/controller/healthz_test.go
+++ b/internal/services/controller/healthz_test.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"castai-agent/internal/config"
+)
+
+func TestNewHealthzProvider(t *testing.T) {
+	t.Run("unhealthy statuses", func(t *testing.T) {
+		cfg := config.Config{Controller: &config.Controller{
+			Interval:                       15 * time.Second,
+			PrepTimeout:                    time.Millisecond,
+			InitialSleepDuration:           time.Millisecond,
+			InitializationTimeoutExtension: time.Millisecond,
+			HealthySnapshotIntervalLimit:   time.Millisecond,
+		}}
+
+		h := NewHealthzProvider(cfg)
+
+		t.Run("should return not initialized error", func(t *testing.T) {
+			require.Error(t, h.Check(nil))
+		})
+
+		t.Run("should return initialize timeout error", func(t *testing.T) {
+			h.Initializing()
+
+			time.Sleep(5 * time.Millisecond)
+
+			require.Error(t, h.Check(nil))
+		})
+
+		t.Run("should return snapshot timeout error", func(t *testing.T) {
+			h.healthyAction()
+
+			time.Sleep(5 * time.Millisecond)
+
+			require.Error(t, h.Check(nil))
+		})
+	})
+
+	t.Run("healthy statuses", func(t *testing.T) {
+		cfg := config.Config{Controller: &config.Controller{
+			Interval:                       15 * time.Second,
+			PrepTimeout:                    10 * time.Minute,
+			InitialSleepDuration:           30 * time.Second,
+			InitializationTimeoutExtension: 5 * time.Minute,
+			HealthySnapshotIntervalLimit:   10 * time.Minute,
+		}}
+
+		h := NewHealthzProvider(cfg)
+
+		t.Run("should return no error when still initializing", func(t *testing.T) {
+			h.Initializing()
+
+			require.NoError(t, h.Check(nil))
+		})
+
+		t.Run("should return no error when timeout after initialization has not yet passed", func(t *testing.T) {
+			h.Initialized()
+
+			require.NoError(t, h.Check(nil))
+		})
+
+		t.Run("should return no error when time since last snapshot has not been long", func(t *testing.T) {
+			h.SnapshotSent()
+
+			require.NoError(t, h.Check(nil))
+		})
+	})
+}

--- a/internal/services/controller/worker.go
+++ b/internal/services/controller/worker.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+
+	"castai-agent/internal/castai"
+	"castai-agent/internal/config"
+	"castai-agent/internal/services/providers/types"
+	"castai-agent/internal/services/version"
+)
+
+type Worker struct {
+	Fn func(ctx context.Context) error
+
+	stop   context.CancelFunc
+	exitCh chan struct{}
+}
+
+func (w *Worker) Start(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	w.exitCh = make(chan struct{})
+	defer close(w.exitCh)
+
+	w.stop = cancel
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := w.Fn(ctx); err != nil {
+			return fmt.Errorf("running controller function: %w", err)
+		}
+	}
+}
+
+func (w *Worker) Stop(log logrus.FieldLogger) {
+	if w.stop == nil {
+		return
+	}
+
+	w.stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	select {
+	case <-w.exitCh:
+	case <-ctx.Done():
+		log.Errorf("waiting for controller to exit: %v", ctx.Err())
+	}
+}
+
+func RunController(
+	log logrus.FieldLogger,
+	clientset kubernetes.Interface,
+	castaiclient castai.Client,
+	provider types.Provider,
+	clusterID string,
+	cfg config.Config,
+	agentVersion *config.AgentVersion,
+	healthzProvider *HealthzProvider,
+) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		log = log.WithField("controller_id", uuid.New().String())
+
+		defer func() {
+			if err := recover(); err != nil {
+				log.Errorf("panic: runtime error: %v", err)
+			}
+		}()
+
+		ctrlCtx, cancelCtrlCtx := context.WithCancel(ctx)
+		defer cancelCtrlCtx()
+
+		v, err := version.Get(log, clientset)
+		if err != nil {
+			return fmt.Errorf("getting kubernetes version: %w", err)
+		}
+
+		log = log.WithField("k8s_version", v.Full())
+
+		f := informers.NewSharedInformerFactory(clientset, 0)
+		ctrl := New(
+			log,
+			f,
+			castaiclient,
+			provider,
+			clusterID,
+			cfg.Controller,
+			v,
+			agentVersion,
+			healthzProvider,
+		)
+		f.Start(ctrlCtx.Done())
+
+		// Run the controller. This is a blocking call.
+		return ctrl.Run(ctrlCtx)
+	}
+}


### PR DESCRIPTION
Agent will now have a healthz endpoint at `:9876`. It has just these checks:
1. If the controller is unable to properly initialize in by default `15m30s` it will become unhealthy.
2. If the controller does not send snapshot after initializing or time since the last snapshot is by default longer than `10m` it will become unhealthy. 