### PR TITLE
Switch off -source image

### DIFF
--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal:8.7-1031-source as rh-ubi
+FROM redhat/ubi8-minimal:8.7-1031 as rh-ubi
 ARG TARGETARCH=amd64
 COPY bin/castai-agent-$TARGETARCH /usr/local/bin/castai-agent
 CMD ["castai-agent"]


### PR DESCRIPTION
The source image creates certificate errors and is much larger than the non-source image. 