### PR TITLE
add license and userId to RH container build.

### DIFF
--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -1,4 +1,6 @@
 FROM redhat/ubi8-minimal:8.7-1031 as rh-ubi
 ARG TARGETARCH=amd64
 COPY bin/castai-agent-$TARGETARCH /usr/local/bin/castai-agent
+COPY LICENCE /licenses/LICENCE
+USER 1002
 CMD ["castai-agent"]


### PR DESCRIPTION
Redhat has a certification process, we need our license and userID specified in the docker build. I've added these functions. 