### PR TITLE
Exit agent when registration fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/goleak v1.1.12
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4

--- a/go.sum
+++ b/go.sum
@@ -463,6 +463,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,31 +8,32 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	require.NoError(t, os.Setenv("API_KEY", "abc"))
-	require.NoError(t, os.Setenv("API_URL", "api.cast.ai"))
+	r := require.New(t)
+	r.NoError(os.Setenv("API_KEY", "abc"))
+	r.NoError(os.Setenv("API_URL", "api.cast.ai"))
 
-	require.NoError(t, os.Setenv("KUBECONFIG", "~/.kube/config"))
+	r.NoError(os.Setenv("KUBECONFIG", "~/.kube/config"))
 
-	require.NoError(t, os.Setenv("PROVIDER", "EKS"))
+	r.NoError(os.Setenv("PROVIDER", "EKS"))
 
-	require.NoError(t, os.Setenv("EKS_ACCOUNT_ID", "123"))
-	require.NoError(t, os.Setenv("EKS_REGION", "eu-central-1"))
-	require.NoError(t, os.Setenv("EKS_CLUSTER_NAME", "eks"))
+	r.NoError(os.Setenv("EKS_ACCOUNT_ID", "123"))
+	r.NoError(os.Setenv("EKS_REGION", "eu-central-1"))
+	r.NoError(os.Setenv("EKS_CLUSTER_NAME", "eks"))
 
 	cfg := Get()
 
-	require.Equal(t, cfg.HealthzPort, 9876)
-	require.Equal(t, cfg.LeaderElection.LockName, "agent-leader-election-lock")
-	require.Equal(t, cfg.LeaderElection.Namespace, "castai-agent")
-	require.Equal(t, "abc", cfg.API.Key)
-	require.Equal(t, "https://api.cast.ai", cfg.API.URL)
+	r.Equal(9876, cfg.HealthzPort)
+	r.Equal("agent-leader-election-lock", cfg.LeaderElection.LockName)
+	r.Equal("castai-agent", cfg.LeaderElection.Namespace)
+	r.Equal("abc", cfg.API.Key)
+	r.Equal("https://api.cast.ai", cfg.API.URL)
 
-	require.Equal(t, "~/.kube/config", cfg.Kubeconfig)
+	r.Equal("~/.kube/config", cfg.Kubeconfig)
 
-	require.Equal(t, "EKS", cfg.Provider)
+	r.Equal("EKS", cfg.Provider)
 
-	require.NotNil(t, cfg.EKS)
-	require.Equal(t, "123", cfg.EKS.AccountID)
-	require.Equal(t, "eu-central-1", cfg.EKS.Region)
-	require.Equal(t, "eks", cfg.EKS.ClusterName)
+	r.NotNil(cfg.EKS)
+	r.Equal("123", cfg.EKS.AccountID)
+	r.Equal("eu-central-1", cfg.EKS.Region)
+	r.Equal("eks", cfg.EKS.ClusterName)
 }

--- a/pkg/log/exporter.go
+++ b/pkg/log/exporter.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const MaxParallelLogs int64 = 20
+const MaxParallelLogs int64 = 100
 
 func SetupLogExporter(registrator *castai.Registrator, logger *logrus.Logger, localLog logrus.FieldLogger, castaiclient castai.Client, cfg *Config) *Exporter {
 	logExporter := &Exporter{


### PR DESCRIPTION
Currently agent will not exit if registration fails, as logs wait indefinitely until clusterID is acquired, bypassing log timeouts.