### PR TITLE
Update build for agent to use 1.20.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.5
 
       - name: Cache Go modules
         uses: actions/cache@v3

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.5
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Use go version not susceptible to below CVEs
CVE-2023-29405
CVE-2023-29404 
CVE-2023-29403
CVE-2023-29402