### PR TITLE
fix: rename ConfigMap conditional informer

### DIFF
--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -119,7 +119,7 @@ func New(
 
 	conditionalInformers := []conditionalInformer{
 		{
-			name:            "configmap",
+			name:            "configmaps",
 			groupVersion:    corev1.SchemeGroupVersion.String(),
 			apiType:         reflect.TypeOf(&corev1.ConfigMap{}),
 			permissionVerbs: []string{"get", "list", "watch"},

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -160,7 +160,7 @@ func TestController_HappyPath(t *testing.T) {
 			APIResources: []metav1.APIResource{
 				{
 					Group: "",
-					Name:  "configmap",
+					Name:  "configmaps",
 					Kind:  "ConfigMap",
 					Verbs: []string{"get", "list", "watch"},
 				},


### PR DESCRIPTION
in order to apply the correct access rules, the informer name should be plural