### PR TITLE
fix: start running controller test ShouldKeepDeltaAfterDelete

### DIFF
--- a/internal/services/controller/controller_exclude_race_test.go
+++ b/internal/services/controller/controller_exclude_race_test.go
@@ -1,6 +1,3 @@
-//go:build !race
-// +build !race
-
 package controller
 
 import (
@@ -51,7 +48,7 @@ func TestController_ShouldKeepDeltaAfterDelete(t *testing.T) {
 	f := informers.NewSharedInformerFactory(clientset, 0)
 	df := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
 
-	version.EXPECT().Full().Return("1.21+").MaxTimes(2)
+	version.EXPECT().Full().Return("1.21+").MaxTimes(3)
 
 	clusterID := uuid.New()
 	log := logrus.New()


### PR DESCRIPTION
Tested locally and in CI multiple times - all good. The call to `versions` is just made 3 times now instead of 2 from some ages ago