### PR TITLE
feat: send cluster deltas with a non-sliding interval

### DIFF
--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -291,7 +291,7 @@ func (c *Controller) Run(ctx context.Context) error {
 			}
 			// Since Mutex.TryLock() acquires a lock on success,
 			// release it immediately to allow the new sending goroutine to do its job.
-			c.sendMu.Unlock()
+			defer c.sendMu.Unlock()
 			c.send(ctx)
 		}, c.cfg.Interval, ctx.Done())
 		return nil
@@ -438,8 +438,6 @@ func (c *Controller) processItem(i interface{}) {
 func (c *Controller) send(ctx context.Context) {
 	c.deltaMu.Lock()
 	defer c.deltaMu.Unlock()
-	c.sendMu.Lock()
-	defer c.sendMu.Unlock()
 
 	nodesByName := map[string]*corev1.Node{}
 	var nodes []*corev1.Node

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -336,8 +336,7 @@ func TestController_ShouldSendByInterval(t *testing.T) {
 							sentFirstTickNotification.Store(true)
 						}
 						time.Sleep(sendDuration)
-						gotSends.Add(1)
-						if gotSends.Load() == tc.wantSends {
+						if gotSends.Add(1) == tc.wantSends {
 							lastSentAt = time.Now()
 						}
 						wg.Done()

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -240,6 +241,157 @@ func TestController_ApiResourcesErrorProcessing(t *testing.T) {
 		Group:   "external.metrics.k8s.io",
 		Version: "v2beta2",
 	}])
+}
+
+func TestController_ShouldSendByInterval(t *testing.T) {
+	tt := []struct {
+		name          string
+		sendInterval  time.Duration
+		sendDurations []time.Duration
+		checkAfter    time.Duration
+		wantSends     int64
+	}{
+		{
+			name:         "should trigger all sends when none exceed allocated intervals",
+			sendInterval: 300 * time.Millisecond,
+			sendDurations: []time.Duration{
+				// Send by 300ms
+				250 * time.Millisecond,
+				// ...by 600ms
+				250 * time.Millisecond,
+				// ...by 900ms
+				250 * time.Millisecond,
+				// ...by 1200ms
+				250 * time.Millisecond,
+			},
+			checkAfter: 1200 * time.Millisecond,
+			wantSends:  4,
+		},
+		{
+			name:         "should trigger all sends when previous send exceeds one interval",
+			sendInterval: 300 * time.Millisecond,
+			sendDurations: []time.Duration{
+				// At 0, 300: idle, previous still sending
+				// Send by 600 ms
+				450 * time.Millisecond,
+				// Send by 600 ms too, since we expect ticker to fire events even between ticks
+				50 * time.Millisecond,
+			},
+			checkAfter: 600 * time.Millisecond,
+			wantSends:  2,
+		},
+		{
+			name:         "should trigger all sends when previous send exceeds two intervals",
+			sendInterval: 300 * time.Millisecond,
+			sendDurations: []time.Duration{
+				// At 0, 300, 600ms: idle, previous still sending
+				// Send by 900 ms
+				650 * time.Millisecond,
+				// Send by 900 ms too, since we expect ticker to fire events even between ticks
+				150 * time.Millisecond,
+			},
+			checkAfter: 900 * time.Millisecond,
+			wantSends:  2,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mockctrl := gomock.NewController(t)
+			castaiclient := mock_castai.NewMockClient(mockctrl)
+			version := mock_version.NewMockInterface(mockctrl)
+			provider := mock_types.NewMockProvider(mockctrl)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: v1.NamespaceDefault, Name: "pod1"}}
+			_, err := delta.Encode(pod)
+			require.NoError(t, err)
+
+			clientset := fake.NewSimpleClientset()
+			metricsClient := metrics_fake.NewSimpleClientset()
+			dynamicClient := dynamic_fake.NewSimpleDynamicClient(runtime.NewScheme())
+
+			version.EXPECT().Full().Return("1.21+").AnyTimes()
+
+			clusterID := uuid.New()
+			log := logrus.New()
+
+			var gotSends atomic.Int64
+			var wg sync.WaitGroup
+			wg.Add(len(tc.sendDurations))
+			var sentFirstTickNotification atomic.Bool
+
+			var firstTickAt time.Time
+			var lastSentAt time.Time
+
+			for _, sendDuration := range tc.sendDurations {
+				castaiclient.EXPECT().
+					SendDelta(gomock.Any(), clusterID.String(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, clusterID string, d *castai.Delta) error {
+						if !sentFirstTickNotification.Load() {
+							firstTickAt = time.Now()
+							sentFirstTickNotification.Store(true)
+						}
+						time.Sleep(sendDuration)
+						gotSends.Add(1)
+						if gotSends.Load() == tc.wantSends {
+							lastSentAt = time.Now()
+						}
+						wg.Done()
+						return nil
+					})
+			}
+
+			agentVersion := &config.AgentVersion{Version: "1.2.3"}
+			castaiclient.EXPECT().ExchangeAgentTelemetry(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+				Return(&castai.AgentTelemetryResponse{}, nil).
+				Do(func(ctx context.Context, clusterID string, req *castai.AgentTelemetryRequest) {
+					require.Equalf(t, "1.2.3", req.AgentVersion, "got request: %+v", req)
+				})
+
+			log.SetLevel(logrus.DebugLevel)
+			ctrl := New(
+				log,
+				clientset,
+				dynamicClient,
+				castaiclient,
+				metricsClient,
+				provider,
+				clusterID.String(),
+				&config.Controller{
+					Interval:             tc.sendInterval,
+					PrepTimeout:          300 * time.Millisecond,
+					InitialSleepDuration: 10 * time.Millisecond,
+				},
+				version,
+				agentVersion,
+				NewHealthzProvider(defaultHealthzCfg, log),
+				clientset.AuthorizationV1().SelfSubjectAccessReviews(),
+				"castai-agent",
+			)
+
+			ctrl.Start(ctx.Done())
+
+			go func() {
+				require.NoError(t, ctrl.Run(ctx))
+			}()
+			wg.Wait()
+
+			require.Equal(t, tc.wantSends, gotSends.Load(), "sends don't match, failing at: %s", time.Now())
+			elapsed := lastSentAt.Sub(firstTickAt)
+			deadline := tc.checkAfter
+			require.LessOrEqualf(t, elapsed, deadline, "elapsed time is greater than deadline: %s > %s", elapsed, deadline)
+
+			wait.Until(func() {
+				if gotSends.Load() == int64(len(tc.sendDurations)) {
+					cancel()
+				}
+			}, 10*time.Millisecond, ctx.Done())
+		})
+	}
+
 }
 
 func TestController_ShouldKeepDeltaAfterDelete(t *testing.T) {


### PR DESCRIPTION
Previously, we sent cluster deltas using a non-sliding interval. The order was like this:
- wait for the time to send
- start sending
- finish sending
- start counting towards the next time to send.

This means that long sends will delay sending the next delta. And if sending the delta is delayed, so is the next autoscaling cycle.

In this commit we move to sending cluster deltas using a non-sliding window.