### PR TITLE
feat: More http client configuration options

### DIFF
--- a/cmd/agent/run.go
+++ b/cmd/agent/run.go
@@ -43,7 +43,7 @@ func run(ctx context.Context) error {
 	remoteLogger := logrus.New()
 	remoteLogger.SetLevel(logrus.Level(cfg.Log.Level))
 	remoteLogger.SetFormatter(&textFormatter)
-	log := remoteLogger.WithField("version", ctx.Value("agentVersion").(*config.AgentVersion).Version)
+	log := remoteLogger.WithField("version", config.VersionInfo.Version)
 	if podName := os.Getenv("SELF_POD_NAME"); podName != "" {
 		log = log.WithField("component_pod_name", podName)
 	}
@@ -112,7 +112,7 @@ func runAgentMode(ctx context.Context, castaiclient castai.Client, log *logrus.E
 	ctx, ctxCancel := context.WithCancel(ctx)
 	defer ctxCancel()
 
-	agentVersion := ctx.Value("agentVersion").(*config.AgentVersion)
+	agentVersion := config.VersionInfo
 
 	// buffer will allow for all senders to push, even though we will only read first error and cancel context after it;
 	// all errors from exitCh are logged

--- a/cmd/dump/run.go
+++ b/cmd/dump/run.go
@@ -22,7 +22,7 @@ func run(ctx context.Context) error {
 
 	logger := logrus.New()
 	logger.SetLevel(logrus.Level(cfg.Log.Level))
-	log := logger.WithField("version", ctx.Value("agentVersion").(*config.AgentVersion).Version)
+	log := logger.WithField("version", config.VersionInfo.Version)
 
 	log.Infof("starting dump of cluster snapshot")
 

--- a/cmd/monitor/run.go
+++ b/cmd/monitor/run.go
@@ -25,7 +25,7 @@ func run(ctx context.Context) error {
 
 	remoteLogger := logrus.New()
 	remoteLogger.SetLevel(logrus.Level(cfg.Log.Level))
-	log := remoteLogger.WithField("version", ctx.Value("agentVersion").(*config.AgentVersion).Version)
+	log := remoteLogger.WithField("version", config.VersionInfo.Version)
 
 	localLog := logrus.New()
 	localLog.SetLevel(logrus.DebugLevel)

--- a/internal/castai/castai.go
+++ b/internal/castai/castai.go
@@ -84,6 +84,7 @@ func NewDefaultRestyClient() (*resty.Client, error) {
 	if host := cfg.HostHeaderOverride; host != "" {
 		restyClient.Header.Set("Host", host)
 	}
+	addUA(restyClient.Header)
 
 	return restyClient, nil
 }
@@ -210,7 +211,8 @@ func (c *client) SendDelta(ctx context.Context, clusterID string, delta *Delta) 
 	req.Header.Set(headerContentEncoding, "gzip")
 	req.Header.Set(headerAPIKey, cfg.Key)
 	req.Header.Set(headerContinuityToken, c.continuityToken)
-	req.Header.Set(headerUserAgent, fmt.Sprintf("castai-agent/%s", config.VersionInfo.Version))
+	addUA(req.Header)
+
 	if host := cfg.HostHeaderOverride; host != "" {
 		req.Header.Set("Host", host)
 	}
@@ -320,4 +322,12 @@ func (c *client) ExchangeAgentTelemetry(ctx context.Context, clusterID string, r
 	}
 
 	return body, nil
+}
+
+func addUA(header http.Header) {
+	version := "unknown"
+	if vi := config.VersionInfo; vi != nil {
+		version = vi.Version
+	}
+	header.Set(headerUserAgent, fmt.Sprintf("castai-agent/%s", version))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,8 +62,12 @@ type Pod struct {
 }
 
 type API struct {
-	Key string `mapstructure:"key"`
-	URL string `mapstructure:"url"`
+	Key                   string        `mapstructure:"key"`
+	URL                   string        `mapstructure:"url"`
+	HostHeaderOverride    string        `mapstructure:"host_header_override"`
+	Timeout               time.Duration `mapstructure:"timeout"`
+	DeltaReadTimeout      time.Duration `mapstructure:"delta_read_timeout"`
+	TotalSendDeltaTimeout time.Duration `mapstructure:"total_send_delta_timeout"`
 }
 
 type EKS struct {
@@ -143,6 +147,10 @@ func Get() Config {
 	if cfg != nil {
 		return *cfg
 	}
+
+	viper.SetDefault("api.timeout", 10*time.Second)
+	viper.SetDefault("api.delta_read_timeout", 2*time.Minute)
+	viper.SetDefault("api.total_send_delta_timeout", 5*time.Minute)
 
 	viper.SetDefault("controller.interval", 15*time.Second)
 	viper.SetDefault("controller.prep_timeout", 10*time.Minute)

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,6 +2,8 @@ package config
 
 import "fmt"
 
+var VersionInfo *AgentVersion
+
 type AgentVersion struct {
 	GitCommit, GitRef, Version string
 }

--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -151,7 +151,7 @@ func CollectSingleSnapshot(ctx context.Context,
 
 	defer queue.ShutDown()
 
-	agentVersion := ctx.Value("agentVersion").(*config.AgentVersion)
+	agentVersion := config.VersionInfo
 
 	d := delta.New(log, clusterID, v.Full(), agentVersion.Version)
 	go func() {

--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -151,9 +151,12 @@ func CollectSingleSnapshot(ctx context.Context,
 
 	defer queue.ShutDown()
 
-	agentVersion := config.VersionInfo
+	agentVersion := "unknown"
+	if vi := config.VersionInfo; vi != nil {
+		agentVersion = vi.Version
+	}
 
-	d := delta.New(log, clusterID, v.Full(), agentVersion.Version)
+	d := delta.New(log, clusterID, v.Full(), agentVersion)
 	go func() {
 		for {
 			i, _ := queue.Get()
@@ -649,7 +652,11 @@ func throttleLog(ctx context.Context, log logrus.FieldLogger, objType string, wa
 				} else {
 					log.Infof("Informer cache for %v synced after %v", objType, time.Since(waitStartedAt))
 				}
-				time.Sleep(window)
+				select {
+				case <-time.After(window):
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	_ "net/http/pprof"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
@@ -30,12 +29,11 @@ var (
 )
 
 func main() {
-
 	ctx := signals.SetupSignalHandler()
-	ctx = context.WithValue(ctx, "agentVersion", &config.AgentVersion{
+	config.VersionInfo = &config.AgentVersion{
 		GitCommit: GitCommit,
 		GitRef:    GitRef,
 		Version:   Version,
-	})
+	}
 	cmd.Execute(ctx)
 }


### PR DESCRIPTION
Some other changes:
- refactor agentVersion to set it as global var in config.go
- print requestID header on HTTP failures
- use proper User-Agent header