### PR TITLE
chore: Add unit test for PodMetrics object informer

### DIFF
--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -41,7 +41,7 @@ import (
 	authorizationtypev1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metrics_v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned"
 
 	"castai-agent/internal/castai"
@@ -770,8 +770,8 @@ func getConditionalInformers(clientset kubernetes.Interface, cfg *config.Control
 			},
 		},
 		{
-			resource:        v1beta1.SchemeGroupVersion.WithResource("pods"),
-			apiType:         reflect.TypeOf(&v1beta1.PodMetrics{}),
+			resource:        metrics_v1beta1.SchemeGroupVersion.WithResource("pods"),
+			apiType:         reflect.TypeOf(&metrics_v1beta1.PodMetrics{}),
 			permissionVerbs: []string{"get", "list"},
 			informerFactory: func() cache.SharedIndexInformer {
 				return custominformers.NewPodMetricsInformer(logger, metricsClient)

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -183,7 +183,7 @@ func TestController_ShouldReceiveDeltasBasedOnAvailableResources(t *testing.T) {
 								item.Data != nil &&
 								strings.Contains(string(*item.Data), expectedGVString) // Hacky but OK given this is for testing purposes.
 						})
-						require.Truef(t, found, "missing object for %s %s", expectedGVString, expected.Kind)
+						require.Truef(t, found, "missing object for %q %q", expectedGVString, expected.Kind)
 						require.NotNil(t, actual.Data)
 						require.JSONEq(t, string(*expected.Data), string(*actual.Data))
 					}


### PR DESCRIPTION
This test was missing. While it doesn't cover everything related, this verifies at least some informer basics.