### PR TITLE
Improve logging for servers and fix setting pprof port

### DIFF
--- a/cmd/agent/run.go
+++ b/cmd/agent/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -263,7 +262,6 @@ func watchExitErrors(ctx context.Context, log *logrus.Entry, exitCh chan error, 
 func runPProf(cfg config.Config, log *logrus.Entry, exitCh chan error) (closeFunc func()) {
 	log.Infof("starting pprof server on port: %d", cfg.PprofPort)
 	addr := portToServerAddr(cfg.PprofPort)
-	checkPort(addr, "pprof", log)
 	pprofSrv := &http.Server{Addr: addr, Handler: http.DefaultServeMux}
 	closeFn := func() {
 		log.Infof("closing pprof server")
@@ -292,7 +290,6 @@ func runHealthzEndpoints(cfg config.Config, log *logrus.Entry, checks map[string
 		"server": healthz.Ping,
 	}, checks)
 	addr := portToServerAddr(cfg.HealthzPort)
-	checkPort(addr, "healthz", log)
 	healthzSrv := &http.Server{Addr: addr, Handler: &healthz.Handler{Checks: allChecks}}
 	closeFunc := func() {
 		log.Infof("closing healthz server")
@@ -313,16 +310,6 @@ func runHealthzEndpoints(cfg config.Config, log *logrus.Entry, checks map[string
 		}
 	}()
 	return closeFunc
-}
-
-func checkPort(address string, serverName string, log *logrus.Entry) {
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		log.Errorf("port required to start %s server is not free, address: %s, error: %v", serverName, address, err)
-		return
-	}
-	defer listener.Close()
-	log.Infof("port required to start %s server is free, address: %s", serverName, address)
 }
 
 func portToServerAddr(port int) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 
 	Static      *Static     `mapstructure:"static"`
 	Controller  *Controller `mapstructure:"controller"`
-	PprofPort   int         `mapstructure:"pprof.port"`
+	PprofPort   int         `mapstructure:"pprof_port"`
 	HealthzPort int         `mapstructure:"healthz_port"`
 
 	MetadataStore *MetadataStoreConfig `mapstructure:"metadata_store"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, os.Setenv("EKS_ACCOUNT_ID", "123"))
 	require.NoError(t, os.Setenv("EKS_REGION", "eu-central-1"))
 	require.NoError(t, os.Setenv("EKS_CLUSTER_NAME", "eks"))
+	require.NoError(t, os.Setenv("PPROF_PORT", "6060"))
 
 	cfg := Get()
 
@@ -26,7 +27,7 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, cfg.LeaderElection.Namespace, "castai-agent")
 	require.Equal(t, "abc", cfg.API.Key)
 	require.Equal(t, "https://api.cast.ai", cfg.API.URL)
-
+	require.Equal(t, 6060, cfg.PprofPort)
 	require.Equal(t, "~/.kube/config", cfg.Kubeconfig)
 
 	require.Equal(t, "EKS", cfg.Provider)


### PR DESCRIPTION
- Add some logs around HTTP servers as we currently have the issue when healthz server is not able to reply on any requests 
- Add direct checking if required port for HTTP server is free
- Changed error handling for errors from `ListenAndServe()`,  inspiration form https://dev.to/mokiat/proper-http-shutdown-in-go-3fji, `http.ErrServerClosed` is the special error, it shouldn't be handled as other errors because then we're getting misleading error message `time="2024-09-25T18:24:46Z" level=error msg="agent stopped with an error: healthz server: http: Server closed" version=v0.64.0` - this shows that agent was closed because server was closed, but in real scenario server was closed because container was killed by Kubernetes
- Fix setting port for pprof server

Example new logs:

```
time="2024-12-11T17:43:19Z" level=info msg="starting pprof server on port: 6060" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk version=local
time="2024-12-11T17:43:19Z" level=info msg="port required to start pprof server is free, address: :6060" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk version=local
time="2024-12-11T17:43:19Z" level=info msg="starting healthz server on port: 9876" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk version=local
time="2024-12-11T17:43:19Z" level=info msg="pprof server ready" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk version=local
time="2024-12-11T17:43:19Z" level=info msg="port required to start healthz server is free, address: :9876" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk version=local
time="2024-12-11T17:43:19Z" level=info msg="healthz server ready" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk version=local
...
time="2024-12-11T17:43:19Z" level=info msg="context done" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk provider=gke version=local
time="2024-12-11T17:43:19Z" level=info msg="stopped leading" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk own_identity=3f079d92-0339-46f4-96a1-477ab86b57d9 provider=gke version=local
time="2024-12-11T17:43:19Z" level=info msg="closing healthz server" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk provider=gke version=local
time="2024-12-11T17:43:19Z" level=warning msg="healthz server closed" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk provider=gke version=local
time="2024-12-11T17:43:19Z" level=info msg="closing pprof server" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk provider=gke version=local
time="2024-12-11T17:43:19Z" level=warning msg="pprof server closed" component_node_name=gke-kasiak-12-11-default-pool-378b0891-f2hw component_pod_name=castai-agent-65db8c867c-kcbmk provider=gke version=local
```