### PR TITLE
feat: Collect Karpenter v1 objects

### DIFF
--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -782,6 +782,36 @@ func getConditionalInformers(clientset kubernetes.Interface, cfg *config.Control
 			},
 		},
 		{
+			groupVersion:    knowngv.KarpenterCoreV1,
+			resource:        "nodepools",
+			kind:            "NodePool",
+			apiType:         reflect.TypeOf(&unstructured.Unstructured{}),
+			permissionVerbs: []string{"get", "list", "watch"},
+			informerFactory: func() cache.SharedIndexInformer {
+				return df.ForResource(knowngv.KarpenterCoreV1.WithResource("nodepools")).Informer()
+			},
+		},
+		{
+			groupVersion:    knowngv.KarpenterCoreV1,
+			resource:        "nodeclaims",
+			kind:            "NodeClaim",
+			apiType:         reflect.TypeOf(&unstructured.Unstructured{}),
+			permissionVerbs: []string{"get", "list", "watch"},
+			informerFactory: func() cache.SharedIndexInformer {
+				return df.ForResource(knowngv.KarpenterCoreV1.WithResource("nodeclaims")).Informer()
+			},
+		},
+		{
+			groupVersion:    knowngv.KarpenterV1,
+			resource:        "ec2nodeclasses",
+			kind:            "EC2NodeClass",
+			apiType:         reflect.TypeOf(&unstructured.Unstructured{}),
+			permissionVerbs: []string{"get", "list", "watch"},
+			informerFactory: func() cache.SharedIndexInformer {
+				return df.ForResource(knowngv.KarpenterV1.WithResource("ec2nodeclasses")).Informer()
+			},
+		},
+		{
 			groupVersion:    datadoghqv1alpha1.GroupVersion,
 			resource:        "extendeddaemonsetreplicasets",
 			kind:            "ExtendedDaemonSetReplicaSet",

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -1103,24 +1103,24 @@ func loadInitialHappyPathData(t *testing.T, scheme *runtime.Scheme) ([]sampleObj
 			Resource: awsNodeTemplatesGvr.Resource,
 			Data:     awsNodeTemplatesData,
 		},
-		//{
-		//	GV:       knowngv.KarpenterCoreV1Beta1,
-		//	Kind:     "NodePool",
-		//	Resource: "nodepools",
-		//	Data:     nodePoolsDataV1Beta1,
-		//},
-		//{
-		//	GV:       knowngv.KarpenterCoreV1Beta1,
-		//	Kind:     "NodeClaim",
-		//	Resource: "nodeclaims",
-		//	Data:     nodeClaimsDataV1Beta1,
-		//},
-		//{
-		//	GV:       knowngv.KarpenterV1Beta1,
-		//	Kind:     "EC2NodeClass",
-		//	Resource: "ec2nodeclasses",
-		//	Data:     ec2NodeClassesDataV1Beta1,
-		//},
+		{
+			GV:       knowngv.KarpenterCoreV1Beta1,
+			Kind:     "NodePool",
+			Resource: "nodepools",
+			Data:     nodePoolsDataV1Beta1,
+		},
+		{
+			GV:       knowngv.KarpenterCoreV1Beta1,
+			Kind:     "NodeClaim",
+			Resource: "nodeclaims",
+			Data:     nodeClaimsDataV1Beta1,
+		},
+		{
+			GV:       knowngv.KarpenterV1Beta1,
+			Kind:     "EC2NodeClass",
+			Resource: "ec2nodeclasses",
+			Data:     ec2NodeClassesDataV1Beta1,
+		},
 		{
 			GV:       datadogExtendedDSReplicaSetsGvr.GroupVersion(),
 			Kind:     "ExtendedDaemonSetReplicaSet",

--- a/internal/services/controller/knowngv/constants.go
+++ b/internal/services/controller/knowngv/constants.go
@@ -6,6 +6,8 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 var (
 	KarpenterCoreV1Alpha5 = schema.GroupVersion{Group: "karpenter.sh", Version: "v1alpha5"}
 	KarpenterCoreV1Beta1  = schema.GroupVersion{Group: "karpenter.sh", Version: "v1beta1"}
+	KarpenterCoreV1       = schema.GroupVersion{Group: "karpenter.sh", Version: "v1"}
 	KarpenterV1Alpha1     = schema.GroupVersion{Group: "karpenter.k8s.aws", Version: "v1alpha1"}
 	KarpenterV1Beta1      = schema.GroupVersion{Group: "karpenter.k8s.aws", Version: "v1beta1"}
+	KarpenterV1           = schema.GroupVersion{Group: "karpenter.k8s.aws", Version: "v1"}
 )


### PR DESCRIPTION
Karpenter V1 objects have the same naming and very similar structure to the v1beta1 objects. Since we are using unstructured type, it should just proxy these without any structure validation.