### PR TITLE
Improve logging and set exit code according to the exit status

### DIFF
--- a/pkg/log/exporter.go
+++ b/pkg/log/exporter.go
@@ -105,3 +105,14 @@ func (ex *exporter) sendLogEvent(clusterID string, e *logrus.Entry) {
 		ex.localLog.Errorf("failed to send logs: %v", err)
 	}
 }
+
+// InvokeLogrusExitHandlers invokes exit handlers set up in SetupLogExporter
+// The handlers are also invoked when any Fatal log entry is made.
+// logrus.Exit runs all the Logrus exit handlers and then terminates the program using os.Exit(code)
+func InvokeLogrusExitHandlers(err error) {
+	if err != nil {
+		logrus.Exit(1)
+	} else {
+		logrus.Exit(0)
+	}
+}


### PR DESCRIPTION
for details please see comments in the code

example logs without changes from this pull request when `provider` env was set to wrong value:
```
time="2025-01-02T15:06:02Z" level=info msg="closing healthz server" component_node_name=ip-192-168-48-224.eu-central-1.compute.internal component_pod_name=castai-agent-749d64cb88-6d2tr version=v0.76.0
time="2025-01-02T15:06:02Z" level=warning msg="healthz server closed" component_node_name=ip-192-168-48-224.eu-central-1.compute.internal component_pod_name=castai-agent-749d64cb88-6d2tr version=v0.76.0
time="2025-01-02T15:06:02Z" level=info msg="closing pprof server" component_node_name=ip-192-168-48-224.eu-central-1.compute.internal component_pod_name=castai-agent-749d64cb88-6d2tr version=v0.76.0
time="2025-01-02T15:06:02Z" level=warning msg="pprof server closed" component_node_name=ip-192-168-48-224.eu-central-1.compute.internal component_pod_name=castai-agent-749d64cb88-6d2tr version=v0.76.0
time="2025-01-02T15:06:02Z" level=info msg="context done" component_node_name=ip-192-168-48-224.eu-central-1.compute.internal component_pod_name=castai-agent-749d64cb88-6d2tr version=v0.76.0
time="2025-01-02T15:06:17Z" level=error msg="failed to send logs after shutdown timed out"
```

example logs with changes from this pull request when `provider` env was set to wrong value:
```
time="2025-01-02T15:09:02Z" level=info msg="closing healthz server" component_node_name=ip-192-168-9-86.eu-central-1.compute.internal component_pod_name=castai-agent-67798b9989-dq7rc version=local
time="2025-01-02T15:09:02Z" level=warning msg="healthz server closed" component_node_name=ip-192-168-9-86.eu-central-1.compute.internal component_pod_name=castai-agent-67798b9989-dq7rc version=local
time="2025-01-02T15:09:02Z" level=info msg="closing pprof server" component_node_name=ip-192-168-9-86.eu-central-1.compute.internal component_pod_name=castai-agent-67798b9989-dq7rc version=local
time="2025-01-02T15:09:02Z" level=warning msg="pprof server closed" component_node_name=ip-192-168-9-86.eu-central-1.compute.internal component_pod_name=castai-agent-67798b9989-dq7rc version=local
time="2025-01-02T15:09:02Z" level=error msg="getting provider: unknown provider \"test\""
time="2025-01-02T15:09:02Z" level=info msg="context done" component_node_name=ip-192-168-9-86.eu-central-1.compute.internal component_pod_name=castai-agent-67798b9989-dq7rc version=local
time="2025-01-02T15:09:17Z" level=error msg="failed to send logs after shutdown timed out"

```