### PR TITLE
Don't return error when attempt of sending delta fails to allow next attempt

### DIFF
--- a/internal/castai/castai.go
+++ b/internal/castai/castai.go
@@ -234,7 +234,7 @@ func (c *client) SendDelta(ctx context.Context, clusterID string, delta *Delta) 
 		resp, err = c.deltaHTTPClient.Do(req)
 		if err != nil {
 			log.Warnf("failed sending delta request: %v", err)
-			return false, fmt.Errorf("sending delta request: %w", err)
+			return false, nil
 		}
 		return true, nil
 	})


### PR DESCRIPTION

`func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionWithContextFunc) error` repeats a condition check with exponential backoff. It immediately returns an error if the condition returns an error, the context is cancelled or hits the deadline,
or if the maximum attempts defined in backoff is exceeded (ErrWaitTimeout).

Agent logs without this change (only one attempt):

```
time="2025-01-16T15:58:27Z" level=warning msg="failed sending delta request: Post \"https://api--mac-2.local.cast.ai/v1/kubernetes/clusters/36b93485-f902-41a7-a8bc-cb7494d1c56b/agent-deltas\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)" attempts=1 cluster_id=36b93485-f902-41a7-a8bc-cb7494d1c56b component_node_name=gke-kasiak-01-16-default-pool-1c35ddc0-nnn5 component_pod_name=castai-agent-6b6d699ff5-d85w4 full_snapshot=true items=408 provider=gke version=v0.77.0
time="2025-01-16T15:58:27Z" level=error msg="failed sending delta: sending delta request: Post \"https://api--mac-2.local.cast.ai/v1/kubernetes/clusters/36b93485-f902-41a7-a8bc-cb7494d1c56b/agent-deltas\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)" cluster_id=36b93485-f902-41a7-a8bc-cb7494d1c56b component_node_name=gke-kasiak-01-16-default-pool-1c35ddc0-nnn5 component_pod_name=castai-agent-6b6d699ff5-d85w4 controller_id=ee9b4c4c-690d-4a9e-b2b7-1c7887ec7a9b k8s_version=1.30.8-gke.1051000 provider=gke version=v0.77.
```


Agent logs with this change (3 attempts):

```
time="2025-01-16T16:06:12Z" level=warning msg="failed sending delta request: Post \"https://api--mac-2.local.cast.ai/v1/kubernetes/clusters/36b93485-f902-41a7-a8bc-cb7494d1c56b/agent-deltas\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)" attempts=1 cluster_id=36b93485-f902-41a7-a8bc-cb7494d1c56b component_node_name=gke-kasiak-01-16-default-pool-1c35ddc0-nnn5 component_pod_name=castai-agent-879b4c747-w6mqx full_snapshot=true items=405 provider=gke version=local
time="2025-01-16T16:06:12Z" level=warning msg="failed sending delta request: Post \"https://api--mac-2.local.cast.ai/v1/kubernetes/clusters/36b93485-f902-41a7-a8bc-cb7494d1c56b/agent-deltas\": io: read/write on closed pipe" attempts=2 cluster_id=36b93485-f902-41a7-a8bc-cb7494d1c56b component_node_name=gke-kasiak-01-16-default-pool-1c35ddc0-nnn5 component_pod_name=castai-agent-879b4c747-w6mqx full_snapshot=true items=405 provider=gke version=local
time="2025-01-16T16:06:12Z" level=warning msg="failed sending delta request: Post \"https://api--mac-2.local.cast.ai/v1/kubernetes/clusters/36b93485-f902-41a7-a8bc-cb7494d1c56b/agent-deltas\": io: read/write on closed pipe" attempts=3 cluster_id=36b93485-f902-41a7-a8bc-cb7494d1c56b component_node_name=gke-kasiak-01-16-default-pool-1c35ddc0-nnn5 component_pod_name=castai-agent-879b4c747-w6mqx full_snapshot=true items=405 provider=gke version=local
time="2025-01-16T16:06:12Z" level=error msg="failed sending delta: timed out waiting for the condition" cluster_id=36b93485-f902-41a7-a8bc-cb7494d1c56b component_node_name=gke-kasiak-01-16-default-pool-1c35ddc0-nnn5 component_pod_name=castai-agent-879b4c747-w6mqx controller_id=9a9adc26-6e57-45b5-a85e-9c10c376f5df k8s_version=1.30.8-gke.1051000 provider=gke version=local
```
