### PR TITLE
Update status for Recommendation CR

### DIFF
--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -643,7 +643,7 @@ func loadInitialHappyPathData(t *testing.T, scheme *runtime.Scheme) ([]sampleObj
 			"apiVersion": "%s/%s",
 			"metadata": {
 				"name": "%s",
-				"namespace": "default"			
+				"namespace": "default"
 			}
 		}`
 		return []byte(fmt.Sprintf(t, kind, group, version, name))
@@ -693,6 +693,16 @@ func loadInitialHappyPathData(t *testing.T, scheme *runtime.Scheme) ([]sampleObj
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      crd.RecommendationGVR.Resource,
 			Namespace: v1.NamespaceDefault,
+		},
+		Status: crd.RecommendationStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "Healthy",
+					Status:             "True",
+					ObservedGeneration: 1,
+					Reason:             "ReconciledSuccessfully",
+				},
+			},
 		},
 	}
 

--- a/internal/services/controller/crd/types.go
+++ b/internal/services/controller/crd/types.go
@@ -26,6 +26,7 @@ type RecommendationSpec struct {
 
 // RecommendationStatus defines the observed state of Recommendation
 type RecommendationStatus struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +genclient


### PR DESCRIPTION
**Description**

- Update the Recommendation CR struct to include the new status field.

    ```yaml
    apiVersion: autoscaling.cast.ai/v1
    kind: Recommendation
    metadata:
      generation: 1
      name: conditional-exit-deployment-deployment
      namespace: default
    spec:
      recommendation:
      - containerName: conditional-container
        requests:
          cpu: 10m
          memory: 10Mi
      targetRef:
        kind: Deployment
        name: conditional-exit-deployment
    status:
      conditions:
        - lastTransitionTime: "2025-01-29T14:23:46Z"
          message: 'The recommendation wasn''t applied immediately as it would create
            a new ReplicaSet. Multiple old ReplicaSets exceeding the history limit suggest
            possible misconfiguration—please review your settings (max allowed: 12, got:
            13).'
          observedGeneration: 1
          reason: SafeguardTriggered
          status: "False"
          type: Healthy
    ```