### PR TITLE
chore: Remove redundant overrides from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,10 +91,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace (
-	github.com/gogo/protobuf v1.1.1 => github.com/gogo/protobuf v1.3.2
-	github.com/gogo/protobuf v1.2.1 => github.com/gogo/protobuf v1.3.2
-	github.com/gogo/protobuf v1.3.1 => github.com/gogo/protobuf v1.3.2
-)
-
 replace github.com/chzyer/logex v1.1.10 => github.com/chzyer/logex v1.2.0


### PR DESCRIPTION
These overrides are redundant. That dependency is already set to be at `v1.3.2`. Ran `go mod tidy` on this commit (did not change `go.sum`).