### PR TITLE
fix: Eliminate a race condition in podmetrics informer

### DIFF
--- a/internal/services/controller/informers/podmetrics.go
+++ b/internal/services/controller/informers/podmetrics.go
@@ -51,7 +51,7 @@ func newMetricsWatch(log logrus.FieldLogger,
 	listOptions metav1.ListOptions,
 	fetchInterval time.Duration) *metricsWatch {
 	return &metricsWatch{
-		closeChan:     make(chan struct{}, 1),
+		closeChan:     make(chan struct{}),
 		resultChan:    make(chan watch.Event),
 		log:           log,
 		client:        client,
@@ -94,10 +94,12 @@ func (m *metricsWatch) Start(ctx context.Context) {
 			}
 		}
 	}, backoff, true, m.closeChan)
+	m.log.Infof("Stopped pod metrics polling")
 }
 
 func (m *metricsWatch) Stop() {
-	m.closeChan <- struct{}{}
+	m.log.Infof("Stopping pod metrics polling")
+	close(m.closeChan)
 }
 
 func (m *metricsWatch) ResultChan() <-chan watch.Event {


### PR DESCRIPTION
We were using a buffered channel to signal the "Stop" action, but we were reading the channel at two places, so we would end up consuming the message inside the `for metrics` loop, and the `backoff.BackoffUntil` wouldn't stop.

We're fixing this by actually closing the channel instead of sending a message. Closed channels always returns `nil` on recv immediately.