### PR TITLE
fix: acquire explicit lock when saving delta events to map

### DIFF
--- a/internal/services/controller/delta/delta.go
+++ b/internal/services/controller/delta/delta.go
@@ -29,7 +29,6 @@ func New(log logrus.FieldLogger, clusterID, clusterVersion, agentVersion string)
 		FullSnapshot:   true,
 		cacheActive:    map[string]*Item{},
 		cacheSpare:     map[string]*Item{},
-		cacheLock:      sync.RWMutex{},
 	}
 }
 
@@ -43,7 +42,7 @@ type Delta struct {
 	FullSnapshot   bool
 	cacheActive    map[string]*Item
 	cacheSpare     map[string]*Item
-	cacheLock      sync.RWMutex
+	cacheLock      sync.Mutex
 }
 
 // Add will add an Item to the Delta Cache. It will debounce the objects.
@@ -59,8 +58,8 @@ func (d *Delta) Add(i *Item) {
 
 	key := itemCacheKey(i)
 
-	d.cacheLock.RLock()
-	defer d.cacheLock.RUnlock()
+	d.cacheLock.Lock()
+	defer d.cacheLock.Unlock()
 	cache := d.cacheActive
 	if other, ok := cache[key]; ok && other.Event == castai.EventAdd && i.Event == castai.EventUpdate {
 		i.Event = castai.EventAdd


### PR DESCRIPTION
When using `RLock` for write operations, we allow for race conditions which might mess up the entire map or lose data (i.e. when the map gets expanded).