### PR TITLE
chore: golangci-lint migrate

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,6 +13,6 @@ jobs:
           go-version: 1.23.8
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,31 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - mock
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
     - gci
-
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(castai-agent)
-
-issues:
-  exclude-dirs:
-    - mock
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(castai-agent)
+  exclusions:
+    generated: lax
+    paths:
+      - mock
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Ran `golangci-lint migrate` in this repository. The older version doesn't work with the linter version I have locally (no longer supported). Nobody complained so either nobody is running it or they are using older linters.

GitHub action also had to be upgraded (to support newer config file) so I picked latest (`v7`). Probably doesn't matter too much.